### PR TITLE
feat: rebuild all components after the version bump

### DIFF
--- a/release.groovy
+++ b/release.groovy
@@ -21,7 +21,7 @@ pipeline {
 
         stage('publish-artifacts') {
             steps {
-                  build job: 'Publish-All-In-One', parameters: [string(name: 'VERSION', value: "${VERSION}")]
+                build job: 'Publish-All-In-One', parameters: [string(name: 'VERSION', value: "${VERSION}")]
             }
         }
 
@@ -32,6 +32,18 @@ pipeline {
                         sh './scripts/release_components.sh $VERSION $BOT $BOTTOKEN'
                     }
                 }
+            }
+        }
+
+        // during the 'release' stage, every repo gets its version bumped, so we need to publish again, sequentially
+        // at this time, all components should already have their snapshot version bumped, so no need to explicitly supply the VERSION parameter
+        stage('publish-new-snapshot') {
+            steps {
+                build job: 'Publish-Component', parameters: [string(name: 'REPO', value: "https://github.com/eclipse-edc/GradlePlugins")]
+                build job: 'Publish-Component', parameters: [string(name: 'REPO', value: "https://github.com/eclipse-edc/Connector")]
+                build job: 'Publish-Component', parameters: [string(name: 'REPO', value: "https://github.com/eclipse-edc/IdentityHub")]
+                build job: 'Publish-Component', parameters: [string(name: 'REPO', value: "https://github.com/eclipse-edc/RegistrationService")]
+                build job: 'Publish-Component', parameters: [string(name: 'REPO', value: "https://github.com/eclipse-edc/FederatedCatalog")]
             }
         }
 

--- a/scripts/test_components.sh
+++ b/scripts/test_components.sh
@@ -24,9 +24,6 @@ pids+=($!)
 ./scripts/github_action.sh "eclipse-edc" "federatedcatalog" "verify.yaml" "" $BOT $BOTTOKEN &
 pids+=($!)
 
-./scripts/github_action.sh "eclipse-edc" "minimumviabledataspace" "cd.yaml" "" $BOT $BOTTOKEN &
-pids+=($!)
-
 # Wait worfklows completion, if any of them fail, the script will fail.
 for pid in "${pids[@]}"; do
   wait "$pid"


### PR DESCRIPTION
Adds a stage to build all components again after the version bump (in `release_components.sh`). 
I also removed the test entry for MVD, because its `main` branch doesn't track snapshots anymore anyway.
